### PR TITLE
Use $PAGER on isatty

### DIFF
--- a/httpie/core.py
+++ b/httpie/core.py
@@ -96,6 +96,9 @@ def main(args=sys.argv[1:], env=Environment()):
                 write_with_colors_win_p3k(**write_kwargs)
             else:
                 write(**write_kwargs)
+                if env.stdout_isatty:
+                    from subprocess import Popen, PIPE
+                    Popen(env.pager, shell=True, stdin=PIPE).communicate(input=env.stdout.getvalue())
 
         except IOError as e:
             if not traceback and e.errno == errno.EPIPE:

--- a/httpie/models.py
+++ b/httpie/models.py
@@ -22,6 +22,7 @@ class Environment(object):
     stdin_isatty = sys.stdin.isatty()
     stdin = sys.stdin
     stdout_isatty = sys.stdout.isatty()
+    pager = os.environ.get('PAGER') or 'less'
 
     config_dir = DEFAULT_CONFIG_DIR
 

--- a/httpie/models.py
+++ b/httpie/models.py
@@ -29,6 +29,9 @@ class Environment(object):
         from colorama.initialise import wrap_stream
         stdout = wrap_stream(sys.stdout, convert=None,
                              strip=None, autoreset=True, wrap=True)
+    elif stdout_isatty:
+        from cStringIO import StringIO
+        stdout = StringIO()
     else:
         stdout = sys.stdout
     stderr = sys.stderr

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import sys
 import re


### PR DESCRIPTION
Very well done! This is Fantastic! Finally a HTTP client that actually shows you uhm well HTTP =) 

Works like a charm, pointed it at the github api and there it is, line for line at your finger tips. What more could you want? Well... if its ok to make one tiny little request.  When making queries with lots of data in the body, like those github datasets, you end up at the bottom of the results completely missing the headers which just flew past and then having tol scroll up every time to get to the part you were mainly interested in. 

We could do with a little paging action would you agree? Want some? All yours! =)

My contribution and gratitude:  this proposal lets the  $PAGER environment variable be queried for a pager of your choice or we fall back to `less`. Pipes and redirects are not affected. Streaming directly to pager so no tmp files or any such nonsense.

Commit messages have more details. Keep up the good work! =)

nJoy!