### PR TITLE
Encode request headers with email.header (discuss)

### DIFF
--- a/httpie/client.py
+++ b/httpie/client.py
@@ -1,3 +1,4 @@
+from email.header import Header
 import json
 import sys
 from pprint import pformat
@@ -42,10 +43,16 @@ def dump_request(kwargs):
 def encode_headers(headers):
     # This allows for unicode headers which is non-standard but practical.
     # See: https://github.com/jakubroztocil/httpie/issues/212
-    return dict(
-        (name, value.encode('utf8') if isinstance(value, str) else value)
-        for name, value in headers.items()
-    )
+
+    ret = {}
+
+    for name, value in headers.items():
+        if isinstance(value, str) and '=?utf-8?' not in value:
+            value = Header(value, charset='utf-8').encode()
+
+        ret[name] = value
+
+    return ret
 
 
 def get_default_headers(args):

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -100,7 +100,7 @@ class Session(BaseConfigDict):
 
         """
         for name, value in request_headers.items():
-            value = value.decode('utf8')
+            value = value.decode('utf8') if hasattr(value, 'decode') else value
             if name == 'User-Agent' and value.startswith('HTTPie/'):
                 continue
 


### PR DESCRIPTION
**Not ready for merging since it causes a test failure. This is for discussion.**

instead of using UTF-8, which doesn't seem to be legal.

See https://github.com/jakubroztocil/httpie/issues/282

cc: @jakubroztocil, @sigmavirus24, @warsaw (author of much of the stdlib code for email and HTTP header parsing)