### PR TITLE
When possible, guess the content-type of the file being sent.

### DIFF
--- a/httpie/input.py
+++ b/httpie/input.py
@@ -618,7 +618,8 @@ def parse_items(items,
             try:
                 with open(os.path.expanduser(value), 'rb') as f:
                     value = (os.path.basename(value),
-                             BytesIO(f.read()))
+                             BytesIO(f.read()),
+                             mimetypes.guess_type(value, strict=False)[0])
             except IOError as e:
                 raise ParseError('"%s": %s' % (item.orig, e))
             target = files


### PR DESCRIPTION
This is a workaround/fix for #271 that should work (or can make it work) in most cases, without having to come up with a specialized syntax for specifying a custom content type.