### PR TITLE
Add support for overriding mime type

### DIFF
--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -217,6 +217,16 @@ output_processing.add_argument(
     )
 )
 
+output_processing.add_argument(
+    '--force-mime',
+    dest='mime',
+    metavar='MIMETYPE',
+    help="""
+    Override the mime type returned by the remote host. Can be used to force
+    prettifying output when the server sets an incorrect Content-Type header.
+    """
+)
+
 
 #######################################################################
 # Output options

--- a/httpie/output/streams.py
+++ b/httpie/output/streams.py
@@ -114,6 +114,7 @@ def get_stream_type(env, args):
             conversion=Conversion(),
             formatting=Formatting(env=env, groups=args.prettify,
                                   color_scheme=args.style),
+            mime_override=args.mime,
         )
     else:
         Stream = partial(EncodedStream, env=env)
@@ -224,11 +225,11 @@ class PrettyStream(EncodedStream):
 
     CHUNK_SIZE = 1
 
-    def __init__(self, conversion, formatting, **kwargs):
+    def __init__(self, conversion, formatting, mime_override, **kwargs):
         super(PrettyStream, self).__init__(**kwargs)
         self.formatting = formatting
         self.conversion = conversion
-        self.mime = self.msg.content_type.split(';')[0]
+        self.mime = mime_override or self.msg.content_type.split(';')[0]
 
     def get_headers(self):
         return self.formatting.format_headers(


### PR DESCRIPTION
Added a mime override argument to the PrettyStream class to allow forcing pretty output when a server does not set the correct Content-Type. 

I'd like some feedback on what I have before going any further. It works, but is there a better way to integrate this? 