### PR TITLE
mention httpie-jwt-auth plugin on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -593,6 +593,7 @@ Auth Plugins
 * `requests-hawk <https://github.com/mozilla-services/requests-hawk>`_: Hawk
 * `httpie-api-auth <https://github.com/pd/httpie-api-auth>`_: ApiAuth
 * `httpie-edgegrid <https://github.com/akamai-open/httpie-edgegrid>`_: EdgeGrid
+* `httpie-jwt-auth <https://github.com/teracyhq/httpie-jwt-auth>`_: JWTAuth
 
 
 =======


### PR DESCRIPTION
Hello guys,

We've released https://pypi.python.org/pypi/httpie-jwt-auth and would like it to be mentioned on README so that everyone could know and use it right away.

Best regards,

Hoat Le