### PR TITLE
Fix trasnsport typo in plugin manager.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Patches and ideas
 * `Nathan LaFreniere <https://github.com/nlf>`_
 * `Matthias Lehmann <https://github.com/matleh>`_
 * `Dennis Brakhane <https://github.com/brakhane>`_
+* `Matt Layman <https://github.com/mblayman>`_

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -22,7 +22,7 @@ DEFAULT_UA = 'HTTPie/%s' % __version__
 
 def get_requests_session():
     requests_session = requests.Session()
-    for cls in plugin_manager.get_trasnsport_plugins():
+    for cls in plugin_manager.get_transport_plugins():
         transport_plugin = cls()
         requests_session.mount(prefix=transport_plugin.prefix,
                                adapter=transport_plugin.get_adapter())

--- a/httpie/plugins/manager.py
+++ b/httpie/plugins/manager.py
@@ -60,6 +60,6 @@ class PluginManager(object):
                 if issubclass(plugin, ConverterPlugin)]
 
     # Adapters
-    def get_trasnsport_plugins(self):
+    def get_transport_plugins(self):
         return [plugin for plugin in self
                 if issubclass(plugin, TransportPlugin)]


### PR DESCRIPTION
I was reading the code and found this plugin in the method name. It worked because there was an equivalent typo in the definition.