### PR TITLE
Added defusedxml for outputting xml values.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,3 +33,4 @@ Patches and ideas
 * `Matthias Lehmann <https://github.com/matleh>`_
 * `Dennis Brakhane <https://github.com/brakhane>`_
 * `Matt Layman <https://github.com/mblayman>`_
+* `Kevin London <https://github.com/kevinlondon>`_

--- a/httpie/output/formatters/xml.py
+++ b/httpie/output/formatters/xml.py
@@ -46,7 +46,6 @@ class XMLFormatter(FormatterPlugin):
                 root = ElementTree.fromstring(body.encode('utf8'))
             except (ElementTree.ParseError, ElementTree.EntitiesForbidden):
                 # Ignore invalid XML errors (skips attempting to pretty print)
-                print 'invalid!'
                 pass
             else:
                 indent(root)

--- a/httpie/output/formatters/xml.py
+++ b/httpie/output/formatters/xml.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import re
-from xml.etree import ElementTree
+from defusedxml import ElementTree
 
 from httpie.plugins import FormatterPlugin
 
@@ -44,8 +44,9 @@ class XMLFormatter(FormatterPlugin):
             # FIXME: orig NS names get forgotten during the conversion, etc.
             try:
                 root = ElementTree.fromstring(body.encode('utf8'))
-            except ElementTree.ParseError:
+            except (ElementTree.ParseError, ElementTree.EntitiesForbidden):
                 # Ignore invalid XML errors (skips attempting to pretty print)
+                print 'invalid!'
                 pass
             else:
                 indent(root)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ tests_require = [
 
 install_requires = [
     'requests>=2.3.0',
-    'Pygments>=1.5'
+    'Pygments>=1.5',
+    'defusedxml==0.4.1',
 ]
 
 ### Conditional dependencies:


### PR DESCRIPTION
I'm doing some scans of popular open source projects using [Bandit](https://github.com/openstack/bandit) and found a potential vulnerability with the xml parsing.

```
>> Issue: Using xml.etree.ElementTree.fromstring to parse untrusted XML data is known to be vulnerable to XML attacks. Replace xml.etree.ElementTree.fromstring with it's defusedxml equivilent function.
   Severity: Medium   Confidence: High
   Location: httpie/httpie/output/formatters/xml.py:46
45              try:
46                  root = ElementTree.fromstring(body.encode('utf8'))
47              except ElementTree.ParseError:
```
I addressed it by adding in defusedxml and a few tests for the xml output options, including the failure conditions. Here are the docs on [defusedxml](https://pypi.python.org/pypi/defusedxml) and the [Python docs](https://docs.python.org/3/library/xml.html#xml-vulnerabilities) talking about the potential vulnerabilities associated.

I know that introducing a new library dependency is not something to be taken lightly, so please let me know if you have any questions or suggestions.