### PR TITLE
Add agent url to the User-Agent

### DIFF
--- a/httpie/client.py
+++ b/httpie/client.py
@@ -17,7 +17,7 @@ urllib3.disable_warnings()
 
 FORM = 'application/x-www-form-urlencoded; charset=utf-8'
 JSON = 'application/json'
-DEFAULT_UA = 'HTTPie/%s' % __version__
+DEFAULT_UA = 'HTTPie/%s (https://github.com/jkbrzt/httpie)' % __version__
 
 
 def get_requests_session():


### PR DESCRIPTION
Add agent url for reference in the user-agent, which is a defacto standard for non-browser user agents [1]

reference: https://en.wikipedia.org/wiki/User_agent#Format_for_automated_agents_.28bots.29

NOTE: the reference is for bots, but should include automation tools such as this one.