### PR TITLE
Add a --default-scheme argument.

### DIFF
--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -88,6 +88,7 @@ positional.add_argument(
     metavar='URL',
     help="""
     The scheme defaults to 'http://' if the URL does not include one.
+    (You can override this with: --default-scheme https)
 
     You can also use a shorthand for localhost
 
@@ -555,6 +556,15 @@ troubleshooting.add_argument(
     default=False,
     help="""
     Prints exception traceback should one occur.
+
+    """
+)
+troubleshooting.add_argument(
+    '--default-scheme',
+    choices=["http", "https"],
+    default="http",
+    help="""
+    Default scheme to use if not specified in the URL.
 
     """
 )

--- a/httpie/input.py
+++ b/httpie/input.py
@@ -137,7 +137,7 @@ class Parser(ArgumentParser):
         if not self.args.ignore_stdin and not env.stdin_isatty:
             self._body_from_file(self.env.stdin)
         if not URL_SCHEME_RE.match(self.args.url):
-            scheme = HTTP
+            scheme = self.args.default_scheme + "://"
 
             # See if we're using curl style shorthand for localhost (:3000/foo)
             shorthand = re.match(r'^:(?!:)(\d*)(/?.*)$', self.args.url)


### PR DESCRIPTION
I work with HTTPS a lot, and make test requests to sites.
I'd love to be able to set

    alias https="http --default-scheme https"

so that I can just write one extra character to query HTTPS data:

    $ https www.facebook.com

This CL adds a `default-scheme` parameter to support this.