### PR TITLE
Remove duplicate setup.py test option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ class PyTest(TestCommand):
     # and runs the tests with no fancy stuff like parallel execution.
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_suite = True
         self.test_args = [
             '--doctest-modules', '--verbose',
             './httpie', './tests'


### PR DESCRIPTION
The removed line is repeated in the method 2 statements down. I don't think both are needed.

I diff-ed the output of `python setup.py test` with and without this commit, and the output was semantically the same.