### PR TITLE
Make it so --auth is not a required argument, so auth plugins can load params from elsewhere than command-line

### DIFF
--- a/httpie/client.py
+++ b/httpie/client.py
@@ -115,9 +115,14 @@ def get_requests_kwargs(args, base_headers=None):
     headers = encode_headers(headers)
 
     credentials = None
-    if args.auth:
+    if args.auth_type:
         auth_plugin = plugin_manager.get_auth_plugin(args.auth_type)()
-        credentials = auth_plugin.get_auth(args.auth.key, args.auth.value)
+
+        if args.auth:
+            credentials = auth_plugin.get_auth(args.auth.key, args.auth.value)
+        elif args.auth_type not in ('basic', 'digest'):
+            # Some plugins like to load these from filesystem or env vars.
+            credentials = auth_plugin.get_auth(None, None)
 
     cert = None
     if args.cert:

--- a/httpie/input.py
+++ b/httpie/input.py
@@ -544,13 +544,14 @@ class AuthCredentialsArgType(KeyValueArgType):
     def __call__(self, string):
         """Parse credentials from `string`.
 
-        ("username" or "username:password").
+        ("username" or "username:password" or nothing).
 
         """
         try:
             return super(AuthCredentialsArgType, self).__call__(string)
         except ArgumentTypeError:
-            # No password provided, will prompt for it later.
+            # Username provided but no password provided.
+            # In this case we will prompt for password (later).
             return self.key_value_class(
                 key=string,
                 value=None,


### PR DESCRIPTION
Some recommend against putting sensitive material on your command-line. So it makes sense if we can avoid putting secret keys on command-line, if there is an auth plugin that will load the creds from filesystem or environment variables.

---

Addresses #431.
Relates somewhat to:
- #378 at #378
- teracyhq/httpie-jwt-auth#3

---

There are auth plugins that may want to load auth credentials
from the filesystem or environment variables.

This is a reasonable option for HMAC-based authentication schemes.
(Case in point: AWS APIs and SDKs work this way.)

So it enables a case where you specify an explicit --auth-type
but no --auth argument, passing None/None as username/password,
right to the auth plugin. It is then up to the auth plugin
to decide whether to load creds from somewhere, or instead
to throw a ValueError etc.

Tested against my fork of guardian/httpie-hmac-auth (forked
just to demonstrate):
    hangtwenty/httpie-hmac-auth@2dee430
