### PR TITLE
Fixes the `interrupted` property

### DIFF
--- a/httpie/downloads.py
+++ b/httpie/downloads.py
@@ -272,7 +272,7 @@ class Download(object):
         return (
             self.finished
             and self.status.total_size
-            and self.status.total_size != self.status.downloaded
+            and self.status.total_size > self.status.downloaded
         )
 
     def chunk_downloaded(self, chunk):


### PR DESCRIPTION
Inside the `Download` class, `interrupted` evaluated to `True` if the `downloaded` size was *`different`*  than the `total_size`. This caused bug #423 where gzipped files where considered "incomplete" even though the download was successful.

This simple PR only changes the way that the `interrupted` property is evaluated - depending on `downloaded` being *less*  than total size and not just *different*