### PR TITLE
Test codestyle

### DIFF
--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -213,7 +213,7 @@ output_processing.add_argument(
     """.format(
         default=DEFAULT_STYLE,
         available='\n'.join(
-            '{0}{1}'.format(8*' ', line.strip())
+            '{0}{1}'.format(8 * ' ', line.strip())
             for line in wrap(', '.join(sorted(AVAILABLE_STYLES)), 60)
         ).rstrip(),
     )

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -243,7 +243,7 @@ def main(args=sys.argv[1:], env=Environment(), custom_log_error=None):
         except requests.TooManyRedirects:
             exit_status = ExitStatus.ERROR_TOO_MANY_REDIRECTS
             log_error('Too many redirects (--max-redirects=%s).',
-                  parsed_args.max_redirects)
+                      parsed_args.max_redirects)
         except Exception as e:
             # TODO: Further distinction between expected and unexpected errors.
             msg = str(e)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,8 +108,8 @@ class TestItemParsing:
 
         # Parsed file fields
         assert 'file' in items.files
-        assert (items.files['file'][1].read().strip().decode('utf8')
-                == FILE_CONTENT)
+        assert (items.files['file'][1].read().strip().
+                decode('utf8') == FILE_CONTENT)
 
     def test_multiple_file_fields_with_same_field_name(self):
         items = input.parse_items([

--- a/tests/test_codestyle.py
+++ b/tests/test_codestyle.py
@@ -1,0 +1,10 @@
+import pycodestyle
+
+
+def test_conformance():
+    """Test that we conform to PEP-8."""
+    style = pycodestyle.StyleGuide(quiet=False, ignore=['E501', 'E241'])
+    style.input_dir('httpie')
+    style.input_dir('tests')
+    result = style.check_files()
+    assert result.total_errors == 0

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     mock
     pytest
     pytest-httpbin>=0.0.6
+    pycodestyle
 
 
 commands =


### PR DESCRIPTION
In this pull-request I added a test for PEP-8 conformance.

E241 and E501 error codes are currently being ignored.

I also fixed some simple codestyle errors so the new tests pass.