### PR TITLE
Fix Issue #496

### DIFF
--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -102,6 +102,7 @@ positional.add_argument(
     'items',
     metavar='REQUEST_ITEM',
     nargs=ZERO_OR_MORE,
+    default=None,
     type=KeyValueArgType(*SEP_GROUP_ALL_ITEMS),
     help=r"""
     Optional key-value pairs to be included in the request. The separator used


### PR DESCRIPTION
I have same problem like https://github.com/jkbrzt/httpie/issues/496 in Python 3.

The [argparse.py#L1430](https://hg.python.org/cpython/file/3.5/Lib/argparse.py#l1430) module said:

```
if kwargs.get('nargs') == ZERO_OR_MORE and 'default' not in kwargs:
    kwargs['required'] = True
```