### PR TITLE
Add Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
 
 env:
   global:
-    - NEWEST_PYTHON=3.5
+    - NEWEST_PYTHON=3.6
 
 python:
   - 2.6
@@ -15,6 +15,7 @@ python:
   - pypy
   - 3.4
   - 3.5
+  - 3.6
 # Currently fails because of a Flask issue
 #  - pypy3
 
@@ -42,12 +43,12 @@ matrix:
     - os: osx
       language: generic
       env:
-        - TOXENV=py35
+        - TOXENV=py36
         - BREW_INSTALL=python3
 
     # Python Codestyle
     - os: linux
-      python: 3.5
+      python: 3.6
       env: CODESTYLE=true
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     - PYTHON: "C:/Python27"
     # Python 3.4 has outdated pip
     # - PYTHON: "C:/Python34"
-    - PYTHON: "C:/Python35"
+    - PYTHON: "C:/Python36"
 
 init:
   - "ECHO %PYTHON%"

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,8 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 
 [tox]
-envlist = py26, py27, py35, pypy, codestyle
+envlist = py26, py27, py35, py36, pypy, codestyle
 
 
 [testenv]


### PR DESCRIPTION
Python 3.6.0 is the newest major release of the Python language, and it contains many new features and optimizations.

Add it to all CI configuration and add latest python versions (3.5 and 3.6) to setup.py